### PR TITLE
Skip calling the gcc compiler

### DIFF
--- a/tools/scan-build/ccc-analyzer
+++ b/tools/scan-build/ccc-analyzer
@@ -419,11 +419,11 @@ my $Output;
 my %Uniqued;
 
 # Forward arguments to gcc.
-my $Status = system($Compiler,@ARGV);
+#my $Status = system($Compiler,@ARGV);
 if (defined $ENV{'CCC_ANALYZER_LOG'}) {
   print STDERR "$Compiler @ARGV\n";
 }
-if ($Status) { exit($Status >> 8); }
+#if ($Status) { exit($Status >> 8); }
 
 # Get the analysis options.
 my $Analyses = $ENV{'CCC_ANALYZER_ANALYSIS'};
@@ -703,5 +703,6 @@ if ($Action eq 'compile' or $Action eq 'link') {
   }
 }
 
-exit($Status >> 8);
+exit();
+#exit($Status >> 8);
 


### PR DESCRIPTION
This eliminates any calls to gcc this avoiding the verbose output. It should not in principal change the static analyzer results other than to make the log files much smaller.
