### PR TITLE
Update scan-build to always remove working dir from path

### DIFF
--- a/tools/scan-build/scan-build
+++ b/tools/scan-build/scan-build
@@ -266,6 +266,7 @@ sub ComputeDigest {
 my $Prefix;
 
 sub UpdatePrefix {
+  return $CurrentDir;
   my $x = shift;
   my $y = basename($x);
   $x =~ s/\Q$y\E$//;
@@ -279,7 +280,7 @@ sub UpdatePrefix {
 }
 
 sub GetPrefix {
-  return $Prefix;
+  return $CurrentDir;
 }
 
 ##----------------------------------------------------------------------------##


### PR DESCRIPTION
@davidlange6 @smuzaffar @degano 
This should cause scan build to remove the working directory from the file paths in the static analyzer reports.
